### PR TITLE
Use data file from build environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # containermetadata-rpm
 
 [![Build Status](https://travis-ci.com/davidcassany/containermetadata-rpm.svg?branch=master)](https://travis-ci.com/davidcassany/containermetadata-rpm)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/b314b10190a74771be1850a13e68618f)](https://www.codacy.com/app/davidcassany/containermetadata-rpm?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=davidcassany/containermetadata-rpm&amp;utm_campaign=Badge_Grade)
 
 This is KIWI hook for OBS that creates a metadata package for container images.
 This the created RPM only contains a single plain text file with file with all


### PR DESCRIPTION
This commit makes use of the data file present in the build environment
to parse it and get release, disturl and build arch variables from
there. If the data file is not present it just skips metadata package
build.